### PR TITLE
Add highlights for markdown and tweak float menu background

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ A soothing dark color scheme for neovim.
 
 ### Terminal (kitty)
 
-<img width="1673" alt="Screenshot of mellow theme in kitty" src="https://user-images.githubusercontent.com/1040966/196249241-173a1636-b74f-4767-b27f-2b3ed02cea26.png">
+![Screenshot of mellow theme terminal](https://user-images.githubusercontent.com/1040966/196249241-173a1636-b74f-4767-b27f-2b3ed02cea26.png)
 
-### Javascript (JSX)
+### JavaScript (JSX)
 
-<img width="1673" alt="Screenshot of mellow theme JS/JSX" src="https://user-images.githubusercontent.com/1040966/196249265-d122fee2-b14f-4c80-9678-f949487755d4.png">
+![Screenshot of mellow theme JS/JSX]("https://user-images.githubusercontent.com/1040966/196249265-d122fee2-b14f-4c80-9678-f949487755d4.png)
 
 ### HTML
 
-<img width="1673" alt="Screenshot of mellow theme HTML" src="https://user-images.githubusercontent.com/1040966/196249274-5846ea9e-cf02-4ec8-9bae-53b900539ee8.png">
+![Screenshot of mellow theme HTML](https://user-images.githubusercontent.com/1040966/196249274-5846ea9e-cf02-4ec8-9bae-53b900539ee8.png)
 
 ### Clojure
 
-<img width="1673" alt="Screenshot of mellow theme Clojure" src="https://user-images.githubusercontent.com/1040966/196249280-c68a6c20-18b8-4747-9a66-dac28e864457.png">
+![Screenshot of mellow theme Clojure](https://user-images.githubusercontent.com/1040966/196249280-c68a6c20-18b8-4747-9a66-dac28e864457.png)
 
 ### Rust
 
-<img width="1673" alt="Screenshot of mellow theme Rust" src="https://user-images.githubusercontent.com/1040966/196249282-20f2097a-1467-4365-9c99-4f7957e98aec.png">
+![Screenshot of mellow theme Rust](https://user-images.githubusercontent.com/1040966/196249282-20f2097a-1467-4365-9c99-4f7957e98aec.png)
 
 ## Palette
 
@@ -72,8 +72,6 @@ use("mellow-theme/mellow.nvim")
 ```
 
 ## Usage
-
-Enable the colorscheme:
 
 ```lua
 -- Lua

--- a/lua/mellow/init.lua
+++ b/lua/mellow/init.lua
@@ -88,7 +88,7 @@ local set_groups = function()
     ["NonText"] = { fg = c.gray02 }, --'~' and '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line).
     ["Normal"] = { fg = c.fg, bg = cfg.transparent and c.none or c.bg }, -- normal text
     ["NormalNC"] = { fg = c.fg, bg = cfg.transparent and c.none or c.bg_dark }, -- normal text
-    ["NormalFloat"] = { fg = c.white, bg = c.bg }, -- Normal text in floating windows.
+    ["NormalFloat"] = { fg = c.white, bg = c.gray01 }, -- Normal text in floating windows.
     ["FloatBorder"] = { fg = c.gray03, bg = c.bg }, -- Border of floating windows.
     ["Pmenu"] = { fg = c.white, bg = c.black }, -- Popup menu: normal item.
     ["PmenuSel"] = { fg = c.bright_white, bg = c.gray03 }, -- Popup menu: selected item.
@@ -162,6 +162,7 @@ local set_groups = function()
     ["@punctuation"] = { fg = c.gray06 },
     ["@punctuation.delimiter"] = { fg = c.gray06 },
     ["@punctuation.bracket"] = { fg = c.gray06 },
+    ["@punctuation.special"] = { fg = c.gray06 },
     ["@string.documentation"] = { fg = c.green, style = cfg.comment_style },
     ["@string.regex"] = { fg = c.blue },
     ["@string.escape"] = { fg = c.magenta },
@@ -209,7 +210,32 @@ local set_groups = function()
     ["@lsp.typemod.variable.defaultLibrary"] = { link = "@variable.builtin" },
     ["@lsp.typemod.variable.injected"] = { link = "@variable" },
 
+    ["@markup.heading"] = { fg = c.gray06, bold = true },
+    ["@markup.heading.1"] = { fg = c.gray06, bold = true, italic = true },
+    ["@markup.heading.1.marker"] = { link = "@comment" },
+    ["@markup.heading.2"] = { fg = c.gray06, bold = true, italic = true },
+    ["@markup.heading.2.marker"] = { link = "@comment" },
+    ["@markup.heading.3"] = { fg = c.gray06, bold = true, italic = true },
+    ["@markup.heading.3.marker"] = { link = "@comment" },
+    ["@markup.heading.4"] = { fg = c.gray06, bold = true, italic = true },
+    ["@markup.heading.4.marker"] = { link = "@comment" },
+    ["@markup.heading.5"] = { fg = c.gray06, bold = true, italic = true },
+    ["@markup.heading.5.marker"] = { link = "@comment" },
+    ["@markup.heading.6"] = { fg = c.gray06, bold = true, italic = true },
+    ["@markup.heading.6.marker"] = { link = "@comment" },
+    ["@markup.link"] = { fg = c.gray06 },
+    ["@markup.link.label"] = { fg = c.cyan },
+    ["@markup.link.url"] = { fg = c.blue },
+    ["@markup.list"] = { fg = c.gray05, bold = true },
+    ["@markup.list.checked"] = { fg = c.gray05 },
+    ["@markup.list.unchecked"] = { fg = c.gray05 },
+    ["@markup.raw.block"] = { fg = c.gray05 },
+    ["@markup.raw.delimiter"] = { fg = c.gray05 },
+    ["@markup.quote"] = { fg = c.gray06 },
+    ["@markup.strikethrough"] = { fg = c.gray04, strikethrough = true },
+
     -- Diagnostics
+    ["DiagnosticOk"] = { fg = c.green },
     ["DiagnosticError"] = { fg = c.red },
     ["DiagnosticWarn"] = { fg = c.yellow },
     ["DiagnosticInfo"] = { fg = c.blue },


### PR DESCRIPTION
Fixes: https://github.com/mellow-theme/mellow.nvim/issues/30

- Adds highlights for markdown and tweaks float menu background.
- Update README.