### PR TITLE
Refactor: Update Neovim Telescope highlights

### DIFF
--- a/lua/mellow/init.lua
+++ b/lua/mellow/init.lua
@@ -319,11 +319,12 @@ local set_groups = function()
     ["NeoTreeTitleBar"] = { fg = c.gray05, bg = c.gray01 },
 
     -- Telescope
-    ["TelescopePreviewTitle"] = { fg = c.black, bg = c.green, bold = true },
-    ["TelescopeResultsTitle"] = { fg = c.bg, bg = c.bg },
-    ["TelescopePromptTitle"] = { fg = c.black, bg = c.cyan, bold = true },
     ["TelescopeBorder"] = { link = "FloatBorder" },
     ["TelescopeNormal"] = { link = "Normal" },
+    ["TelescopeTitle"] = { fg = c.magenta },
+    ["TelescopePreviewTitle"] = { link = "TelescopeTitle" },
+    ["TelescopeResultsTitle"] = { link = "TelescopeTitle" },
+    ["TelescopePromptTitle"] = { link = "TelescopeTitle" },
     ["TelescopePromptBorder"] = { fg = c.gray01, bg = c.gray01 },
     ["TelescopePromptNormal"] = { fg = c.gray06, bg = c.gray01 },
     ["TelescopePromptCounter"] = { fg = c.gray04, bg = c.gray01 },

--- a/lua/mellow/init.lua
+++ b/lua/mellow/init.lua
@@ -319,15 +319,15 @@ local set_groups = function()
     ["NeoTreeTitleBar"] = { fg = c.gray05, bg = c.gray01 },
 
     -- Telescope
-    ["TelescopeBorder"] = { fg = c.bg, bg = c.bg },
-    ["TelescopeNormal"] = { fg = c.fg, bg = c.bg },
     ["TelescopePreviewTitle"] = { fg = c.black, bg = c.green, bold = true },
     ["TelescopeResultsTitle"] = { fg = c.bg, bg = c.bg },
     ["TelescopePromptTitle"] = { fg = c.black, bg = c.cyan, bold = true },
+    ["TelescopeBorder"] = { link = "FloatBorder" },
+    ["TelescopeNormal"] = { link = "Normal" },
     ["TelescopePromptBorder"] = { fg = c.gray01, bg = c.gray01 },
     ["TelescopePromptNormal"] = { fg = c.gray06, bg = c.gray01 },
     ["TelescopePromptCounter"] = { fg = c.gray04, bg = c.gray01 },
-    ["TelescopeMatching"] = { fg = c.yellow, underline = true },
+    ["TelescopeMatching"] = { link = "Search" },
   }
 
   for name, val in pairs(highlights) do


### PR DESCRIPTION
A few updates to the Telescope highlights for improving consistency, leveraging existing highlights, and improving contrast between Telescope and underlying buffers

Updates:

- titles use consistent highlighting, and their prominence has been reduced
- matches in the 'Results' pane use the existing search highlights, i.e. when using `/` or `?` in a buffer
- added borders to the results and preview panes to improve contrast between buffer text and Telescope text

After updates:

![screenshot-2024-05-04-19-28-21](https://github.com/mellow-theme/mellow.nvim/assets/1510520/4519eb4d-d0a4-4184-adac-ce217061e1af)


Before updates:

![screenshot-2024-05-04-19-29-00](https://github.com/mellow-theme/mellow.nvim/assets/1510520/6eb5c06f-4f6b-474a-bd96-99dfe9a06a34)
