### PR TITLE
Feat: add Neovim highlights for flash.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A soothing dark color scheme for neovim.
 - [hop.nvim](https://github.com/phaazon/hop.nvim)
 - [nvim-navic](https://github.com/SmiteshP/nvim-navic)
 - [nvim-notify](https://github.com/rcarriga/nvim-notify)
+- [flash.nvim](https://github.com/folke/flash.nvim)
 
 ## Requirements
 

--- a/lua/mellow/init.lua
+++ b/lua/mellow/init.lua
@@ -328,6 +328,15 @@ local set_groups = function()
     ["TelescopePromptNormal"] = { fg = c.gray06, bg = c.gray01 },
     ["TelescopePromptCounter"] = { fg = c.gray04, bg = c.gray01 },
     ["TelescopeMatching"] = { fg = c.yellow, underline = true },
+
+    -- Flash
+    ["FlashBackdrop"] = { link = "Comment" },
+    ["FlashCurrent"] = { link = "IncSearch" },
+    ["FlashCursor"] = { bg = c.bright_blue, fg = c.bg_dark, bold = true },
+    ["FlashLabel"] = { bg = c.cyan, bold = true, fg = c.bg_dark },
+    ["FlashMatch"] = { link = "Search" },
+    ["FlashPrompt"] = { link = "MsgArea" },
+    ["FlashPromptIcon"] = { link = "Special" },
   }
 
   for name, val in pairs(highlights) do


### PR DESCRIPTION
Flash is great for jumping to searches in and between buffers: https://github.com/folke/flash.nvim

`t | T | f | F` motions:

![screenshot-2024-05-04-20-06-05](https://github.com/mellow-theme/mellow.nvim/assets/1510520/8e69b293-e92b-42a2-8054-3c58b68375f2)

search motions:

![screenshot-2024-05-04-20-07-23](https://github.com/mellow-theme/mellow.nvim/assets/1510520/e9f1bd7c-362f-4432-a2da-a3013d8ba9e5)

search with backdrop:

![screenshot-2024-05-04-20-08-02](https://github.com/mellow-theme/mellow.nvim/assets/1510520/298bca0b-5b5c-4f2d-b974-cfbba10c8b1c)

treesitter selections:

![screenshot-2024-05-04-20-08-48](https://github.com/mellow-theme/mellow.nvim/assets/1510520/b9dc5458-86cf-4f0a-a185-0d26ad51be59)