### PR TITLE
Add kitty theme metadata for autoupdates

### DIFF
--- a/extras/kitty/mellow.conf
+++ b/extras/kitty/mellow.conf
@@ -1,4 +1,10 @@
-# Mellow colorscheme for kitty
+# vim:ft=kitty
+## name: Mellow
+## license: MIT
+## upstream: https://raw.githubusercontent.com/mellow-theme/mellow.nvim/refs/heads/main/extras/kitty/mellow.conf
+## blurb: A soothing, dark color palette.
+## Crafted to be easy on the eyes with a focus on code readability.
+
 cursor #e3e2e5
 foreground #c9c7cd
 background #161617


### PR DESCRIPTION
Hi!

I'd like to see this theme in [kitty-themes](https://github.com/kovidgoyal/kitty-themes) main. I added required metadata and after merging this I can make PR to kitty-themes.
