### PR TITLE
Distinct Coloring for Function Parameter Variables

### DIFF
--- a/lua/mellow/init.lua
+++ b/lua/mellow/init.lua
@@ -179,7 +179,7 @@ local set_groups = function()
     ["@tag"] = { fg = c.cyan },
     ["@tag.attribute"] = { fg = c.bright_blue, italic = true },
     ["@tag.delimiter"] = { fg = c.gray06 },
-    ["@type.builtin"] = { fg = c.magenta },
+    ["@type.builtin"] = { fg = c.bright_red },
     ["@variable"] = { fg = c.fg, style = cfg.variable_style },
     ["@variable.builtin"] = { fg = c.blue, style = cfg.variable_style },
     ["@variable.member"] = { fg = c.white },


### PR DESCRIPTION
Function parameter variables are currently sharing the color with their type. The code is more readable when they have distinct colors. This PR addresses this issue by setting function parameter variable name color to `fg` color.

Before:
<img width="558" height="269" alt="Screenshot From 2025-07-13 15-50-19" src="https://github.com/user-attachments/assets/03d8e766-8a2f-494e-9471-800125e67867" />

After:
<img width="558" height="269" alt="Screenshot From 2025-07-13 15-32-14" src="https://github.com/user-attachments/assets/1a7f530a-f3c1-4fed-9f3f-7b56bb86684e" />
