### PR TITLE
make telescope.nvim's borders colors differ from the bg color

### DIFF
--- a/lua/mellow/init.lua
+++ b/lua/mellow/init.lua
@@ -368,12 +368,12 @@ local set_groups = function()
     ["NeoTreeTitleBar"] = { fg = c.gray05, bg = c.gray01 },
 
     -- Telescope
-    ["TelescopeBorder"] = { fg = c.bg, bg = c.bg },
+    ["TelescopeBorder"] = { fg = c.gray03, bg = c.bg },
     ["TelescopeNormal"] = { fg = c.fg, bg = c.bg },
     ["TelescopePreviewTitle"] = { fg = c.black, bg = c.green, bold = true },
     ["TelescopeResultsTitle"] = { fg = c.bg, bg = c.bg },
     ["TelescopePromptTitle"] = { fg = c.black, bg = c.cyan, bold = true },
-    ["TelescopePromptBorder"] = { fg = c.gray01, bg = c.gray01 },
+    ["TelescopePromptBorder"] = { fg = c.gray03, bg = c.gray01 },
     ["TelescopePromptNormal"] = { fg = c.gray06, bg = c.gray01 },
     ["TelescopePromptCounter"] = { fg = c.gray04, bg = c.gray01 },
     ["TelescopeMatching"] = { fg = c.yellow, underline = true },


### PR DESCRIPTION
Make telescope's window and prompt border colors differ from the background color so they are visible.

**Before**
<img width="958" height="1080" alt="2025-07-26-144429_hyprshot" src="https://github.com/user-attachments/assets/09b399fb-d933-4738-872b-cace246fe829" />
**After**
<img width="959" height="1080" alt="2025-07-26-144401_hyprshot" src="https://github.com/user-attachments/assets/d6edf2bf-2e53-49bb-a542-c15559013a96" />
