### PR TITLE
feat: add more contrast for mini.pick marked items

### DIFF
--- a/lua/mellow/init.lua
+++ b/lua/mellow/init.lua
@@ -434,6 +434,7 @@ local set_groups = function()
     ["MiniMapNormal"] = { fg = c.gray04, bg = c.gray01 },
     ["MiniPickMatchRanges"] = { fg = c.cyan, bold = true },
     ["MiniPickMatchCurrent"] = { bg = c.gray02, bold = true },
+    ["MiniPickMatchMarked"] = { bg = c.gray04 },
     ["MiniPickPrompt"] = { fg = c.blue, bold = true },
     ["MiniPickPromptPrefix"] = { fg = c.magenta, bold = true },
     ["MiniStarterInactive"] = { fg = c.gray04 },


### PR DESCRIPTION
When I added highlight groups for "mini.pick", I should have added this one as well because marked items in the picker are not easily visible.

## Before
<img width="1073" height="1016" alt="Screenshot 2025-07-26 at 9 32 41 AM" src="https://github.com/user-attachments/assets/4add453d-6250-432d-85c2-1a0db5f9e125" />

## After
<img width="1073" height="1016" alt="Screenshot 2025-07-26 at 9 32 20 AM" src="https://github.com/user-attachments/assets/97d48e07-2dd9-4a42-8c03-4d8a27185af2" />
