### PR TITLE
fix: make current tab more visible in mini.tabline

### DIFF
--- a/lua/mellow/init.lua
+++ b/lua/mellow/init.lua
@@ -453,11 +453,12 @@ local set_groups = function()
     ["MiniStatuslineFileinfo"] = { fg = c.gray06, bg = c.gray03 },
     ["MiniStatuslineDevinfo"] = { fg = c.gray06, bg = c.gray03 },
     ["MiniStatuslineFilename"] = { fg = c.white, bold = true },
-    ["MiniTablineCurrent"] = { fg = c.blue, bg = c.black, bold = true },
-    ["MiniTablineVisible"] = { fg = c.gray07, bg = c.black },
+    ["MiniTablineCurrent"] = { fg = c.blue, bg = c.bg, bold = true },
+    ["MiniTablineFill"] = { bg = c.black },
+    ["MiniTablineVisible"] = { fg = c.gray06, bg = c.black, bold = true },
     ["MiniTablineModifiedCurrent"] = { fg = c.black, bg = c.blue, bold = true },
     ["MiniTablineModifiedHidden"] = { fg = c.black, bg = c.gray05, bold = true },
-    ["MiniTablineModifiedVisible"] = { fg = c.black, bg = c.gray07, bold = true },
+    ["MiniTablineModifiedVisible"] = { fg = c.black, bg = c.gray06, bold = true },
     ["MiniTablineTabpagesection"] = { fg = c.black, bg = c.green, bold = true },
   }
 


### PR DESCRIPTION
These changes improve the original `mini.tabline` settings I had originally submitted. Specifically, the currently selected tab is now more visible and easier to track as you move between buffers because both the foreground and now the background are visually different from the rest of the tabs. See tabline in the screenshots below:

## Before
<img width="1290" height="852" alt="Screenshot 2025-09-01 at 1 28 24 PM" src="https://github.com/user-attachments/assets/eaa47201-879e-4e78-a5e1-9a60c3e9b1e0" />

## After
<img width="1290" height="852" alt="Screenshot 2025-09-01 at 1 28 44 PM" src="https://github.com/user-attachments/assets/c0fbf2b4-50bf-4e13-8c47-e6321e47c271" />


